### PR TITLE
Update HDLx2416.h

### DIFF
--- a/HDLx2416.h
+++ b/HDLx2416.h
@@ -10,7 +10,7 @@
 #ifndef HDLx2416_h
 #define HDLx2416_h
 
-#include "WProgram.h"
+#include "Arduino.h"
 #include <inttypes.h>
 
 /*


### PR DESCRIPTION
wProgram.h is no longer used to tilt the compiler because it is an obsolete library.
you have to update with Arduino.h